### PR TITLE
Use a non-cache version of Coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A python package for Target Controlled Infusions.
 Spawned from the NHS Hack Day project https://github.com/JMathiszig-Lee/Propofol, this splits out useful code into a package and updates it to python3
 
 [![Build Status](https://travis-ci.org/JMathiszig-Lee/PyTCI.svg?branch=master)](https://travis-ci.org/JMathiszig-Lee/PyTCI)
-[![Coverage Status](https://coveralls.io/repos/github/JMathiszig-Lee/PyTCI/badge.svg?branch=master)](https://coveralls.io/github/JMathiszig-Lee/PyTCI?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/JMathiszig-Lee/PyTCI/badge.svg?branch=master&kill_cache=1)](https://coveralls.io/github/JMathiszig-Lee/PyTCI?branch=master)
 
 # Installation
 if using pip


### PR DESCRIPTION
For accurate code coverage status